### PR TITLE
docs: add the guide for contributors

### DIFF
--- a/CONTRIBUTORS_GUIDE.md
+++ b/CONTRIBUTORS_GUIDE.md
@@ -14,6 +14,8 @@ We're really glad you're reading this, because we need volunteer developers to h
 
 The best way to contribute to our projects is to apply to the issues <a href="https://github.com/PayStell/paystell-website/issues" target="_blank">here</a> .
 
+PRs are not allowed; all PRs must originate from an assigned issue.
+
 
 ---
 
@@ -58,21 +60,21 @@ The best way to contribute to our projects is to apply to the issues <a href="ht
 
    ```bash
    git add .
-   git commit -m "[type] description"
+   git commit -m "type: description"
    ```
 
    > Types and when to use them:
 
-   - `[feat]` A new feature
-   - `[fix]` A bug fix
-   - `[docs]` Documentation changes
-   - `[style]` Changes that do not affect the meaning of the code (formatting, etc.)
-   - `[refactor]` Code changes that neither fix a bug nor add a feature
-   - `[perf]` Changes that improve performance
-   - `[test]` Adding missing tests or correcting existing tests
-   - `[build]` Changes that affect the build system or external dependencies
-   - `[ci]` Changes to CI configuration files and scripts
-   - `[chore]` Maintenance changes that do not fall into any of the other categories
+   - `feat:` A new feature
+   - `fix:` A bug fix
+   - `docs:` Documentation changes
+   - `style:` Changes that do not affect the meaning of the code (formatting, etc.)
+   - `refactor:` Code changes that neither fix a bug nor add a feature
+   - `perf:` Changes that improve performance
+   - `test:` Adding missing tests or correcting existing tests
+   - `build:` Changes that affect the build system or external dependencies
+   - `ci:` Changes to CI configuration files and scripts
+   - `chore:` Maintenance changes that do not fall into any of the other categories
 
 ---
 

--- a/CONTRIBUTORS_GUIDE.md
+++ b/CONTRIBUTORS_GUIDE.md
@@ -1,0 +1,108 @@
+# 🌟 Contributing Guide | PayStell
+
+We’re excited you’re interested in contributing! Please follow these steps to ensure a smooth and efficient collaboration process.
+
+🎉 Thank you for being interested in contributing to the PayStell project! 🎉
+
+Feel welcome and read the following sections in order to know how to ask questions and how to work on something.
+
+Please make sure you are welcoming and friendly in all of our spaces.
+
+We're really glad you're reading this, because we need volunteer developers to help this project come to fruition. 👏
+
+## 👨🏻‍💻 Issues
+
+The best way to contribute to our projects is to apply to the issues <a href="https://github.com/PayStell/paystell-website/issues" target="_blank">here</a> .
+
+
+---
+
+## 1️⃣ Fork the Repository
+
+- Click the **Fork** button in the top-right corner to create a copy of the repository under your account.
+
+---
+
+## 2️⃣ Clone the Fork
+
+- Clone the forked repository to your local machine by running the following command:
+
+   ```bash
+   git clone https://github.com/YOUR_USERNAME/REPOSITORY_NAME.git
+   ```
+
+- Replace `YOUR_USERNAME` and `REPOSITORY_NAME` with your GitHub username and the repository name.
+
+---
+
+## 3️⃣ Create a new branch or use the main branch
+
+- Create a branch name based on the type of change (e.g., `feat/name-related-issue`, `docs/name-related-issue`).
+
+   ```bash
+   git checkout -b branch-name
+   ```
+
+   > Example: `docs/update-readme` or `fix/bottom-bug`.
+
+---
+
+## 4️⃣ Make Changes and Write Atomic Commits
+
+- Make changes in your local repository
+- Follow **atomic commit principles**:
+
+   - Each commit should address a single, logical change.
+   - Avoid bundling unrelated changes in a single commit. In case you want to add additional items, please ask the mainteiners first.
+   - Write clear and descriptive commit messages using the format:
+
+   ```bash
+   git add .
+   git commit -m "[type] description"
+   ```
+
+   > Types and when to use them:
+
+   - `[feat]` A new feature
+   - `[fix]` A bug fix
+   - `[docs]` Documentation changes
+   - `[style]` Changes that do not affect the meaning of the code (formatting, etc.)
+   - `[refactor]` Code changes that neither fix a bug nor add a feature
+   - `[perf]` Changes that improve performance
+   - `[test]` Adding missing tests or correcting existing tests
+   - `[build]` Changes that affect the build system or external dependencies
+   - `[ci]` Changes to CI configuration files and scripts
+   - `[chore]` Maintenance changes that do not fall into any of the other categories
+
+---
+
+## 5️⃣ Run the Project Locally
+
+- Ensure the project runs correctly after making your changes.
+- Follow the project-specific setup instructions to test your changes locally.
+
+---
+
+## 6️⃣ Push Your Changes
+
+- Push your changes to your forked repository:
+
+   ```bash
+   git push origin your-branch-name
+   ```
+   > - Replace `your-branch-name` with the name of your branch.
+---
+
+## 7️⃣ Create a Pull Request (PR)
+
+- Navigate to your forked repository on GitHub.
+- Click **New Pull Request** and select your branch to merge into the `main` of the original repository.
+
+---
+
+## 📝 Additional Notes
+
+- Make sure your code adheres to the repository’s coding standards.
+- Respect the project maintainers' feedback and requested changes.
+
+Thank you for contributing! 🤝🏼


### PR DESCRIPTION
# Pull Request Overview

## 📝 Summary
Create a guide for developers who want to contribute to the project. Generating a general nomenclature and rules.

### 🔗 Related Issues
- Closes #5  .

## 🔄 Changes Made
Add contribution guide.

## 🖼️ Current Output
<img width="307" alt="Contributors Guide PayStell" src="https://github.com/user-attachments/assets/743d846b-d370-4197-8542-c0cb9da37c68">

## 💬 Comments
I hope the solution solves what you requested, please let me know of any changes I need to make. Best regards.