### PR TITLE
feat: Creating the dashboard-route with empty content

### DIFF
--- a/paystell-frontend/src/app/dashboard/page.tsx
+++ b/paystell-frontend/src/app/dashboard/page.tsx
@@ -1,0 +1,7 @@
+export default function DashboardPage() {
+    return (
+        <main className="flex min-h-screen flex-col p-8">
+            <h1 className="text-2xl font-semibold">Dashboard</h1>
+        </main>
+    );
+}


### PR DESCRIPTION
# Pull Request Overview

## 📝 Summary
This PR is creating the dashboard route with an empty content for now. Solves this issue #10 

### 🔗 Related Issues
- Closes #10 

## 🔄 Changes Made
I added the dashboard directory with the page inside of it to start including content.

## 🖼️ Current Output
![image](https://github.com/user-attachments/assets/81a5ff45-72f0-4ef7-991c-47f925b49fea)
