### PR TITLE
feat/add-custom-link-branding-options

### DIFF
--- a/paystell-frontend/src/components/dashboard/links/builder/BrandingTab/index.tsx
+++ b/paystell-frontend/src/components/dashboard/links/builder/BrandingTab/index.tsx
@@ -1,0 +1,223 @@
+import React, { useRef } from 'react';
+import { BrandingFormData, ColorPalette } from './types';
+import { Label } from "@/components/ui/label";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+
+// Fix for select component imports - use a standard select instead
+// since your UI library seems to have different export names
+
+interface BrandingTabProps {
+  data: BrandingFormData;
+  onChange: (data: Partial<BrandingFormData>) => void;
+}
+
+const colorPalettes: Record<ColorPalette, { primary: string; secondary: string; background: string }> = {
+  'modern-blue': { primary: '#001A2C', secondary: '#FFFFFF', background: '#F1F5F9' },
+  'forest-green': { primary: '#0E5E41', secondary: '#E7FAF0', background: '#F1F9F5' },
+  'royal-purple': { primary: '#4C1D95', secondary: '#F3E8FF', background: '#F8F5FF' },
+  'sunset-orange': { primary: '#C2410C', secondary: '#FFF7ED', background: '#FFF9F5' },
+  'ocean-blue': { primary: '#0369A1', secondary: '#E0F7FF', background: '#F0FAFF' },
+  'dark-mode': { primary: '#111827', secondary: '#374151', background: '#1F2937' }
+};
+
+const BrandingTab: React.FC<BrandingTabProps> = ({ data, onChange }) => {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  
+  const handleColorPaletteChange = (palette: ColorPalette) => {
+    const colors = colorPalettes[palette];
+    onChange({
+      colorPalette: palette,
+      primaryColor: colors.primary,
+      secondaryColor: colors.secondary,
+      backgroundColor: colors.background
+    });
+  };
+  
+  const handleColorChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+    onChange({ [name]: value });
+  };
+  
+  const handleLogoChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files && e.target.files[0];
+    if (file) {
+      onChange({ logo: file });
+    }
+  };
+
+  const handleLogoRemove = () => {
+    if (fileInputRef.current) {
+      fileInputRef.current.value = '';
+    }
+    onChange({ logo: null });
+  };
+
+  // Fix for the any type parameter
+  const handleLogoPositionChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    onChange({ logoPosition: e.target.value as 'top' | 'none' });
+  };
+
+  const resetColors = () => {
+    const palette = data.colorPalette;
+    const colors = colorPalettes[palette];
+    onChange({
+      primaryColor: colors.primary,
+      secondaryColor: colors.secondary,
+      backgroundColor: colors.background
+    });
+  };
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <div className="flex justify-between items-center mb-2">
+          <h3 className="font-medium">Color Palettes</h3>
+          <Button 
+            onClick={resetColors}
+            variant="ghost"
+            size="sm"
+            className="text-blue-600 hover:text-blue-800"
+          >
+            Reset Colors
+          </Button>
+        </div>
+        <div className="grid grid-cols-3 gap-4">
+          {Object.entries(colorPalettes).map(([key, colors]) => (
+            <button
+              key={key}
+              onClick={() => handleColorPaletteChange(key as ColorPalette)}
+              className={`flex flex-col items-center p-2 border rounded hover:bg-gray-50 ${
+                data.colorPalette === key ? 'border-blue-500 ring-2 ring-blue-200' : 'border-gray-200'
+              }`}
+            >
+              <div 
+                className="w-6 h-6 rounded-full mb-1"
+                style={{ backgroundColor: colors.primary }}
+              />
+              <span className="text-xs capitalize">{key.replace('-', ' ')}</span>
+            </button>
+          ))}
+        </div>
+      </div>
+      
+      <div>
+        <h3 className="font-medium mb-2">Custom Colors</h3>
+        <div className="grid grid-cols-3 gap-4">
+          <div>
+            <label htmlFor="primaryColor" className="block text-xs mb-1">Primary</label>
+            <div className="flex">
+              <input
+                type="color"
+                id="primaryColor"
+                name="primaryColor"
+                value={data.primaryColor}
+                onChange={handleColorChange}
+                className="w-8 h-8 p-0 border-0"
+              />
+              <input
+                type="text"
+                value={data.primaryColor.toUpperCase()}
+                onChange={handleColorChange}
+                name="primaryColor"
+                className="flex-grow ml-2 p-1 text-xs border border-gray-300 rounded"
+              />
+            </div>
+          </div>
+          
+          <div>
+            <label htmlFor="secondaryColor" className="block text-xs mb-1">Secondary</label>
+            <div className="flex">
+              <input
+                type="color"
+                id="secondaryColor"
+                name="secondaryColor"
+                value={data.secondaryColor}
+                onChange={handleColorChange}
+                className="w-8 h-8 p-0 border-0"
+              />
+              <input
+                type="text"
+                value={data.secondaryColor.toUpperCase()}
+                onChange={handleColorChange}
+                name="secondaryColor"
+                className="flex-grow ml-2 p-1 text-xs border border-gray-300 rounded"
+              />
+            </div>
+          </div>
+          
+          <div>
+            <label htmlFor="backgroundColor" className="block text-xs mb-1">Background</label>
+            <div className="flex">
+              <input
+                type="color"
+                id="backgroundColor"
+                name="backgroundColor"
+                value={data.backgroundColor}
+                onChange={handleColorChange}
+                className="w-8 h-8 p-0 border-0"
+              />
+              <input
+                type="text"
+                value={data.backgroundColor.toUpperCase()}
+                onChange={handleColorChange}
+                name="backgroundColor"
+                className="flex-grow ml-2 p-1 text-xs border border-gray-300 rounded"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+      
+      <div>
+        <label className="block font-medium mb-2">Brand Logo</label>
+        <div className="border border-gray-300 rounded p-4">
+          <input
+            type="file"
+            id="logo"
+            name="logo"
+            ref={fileInputRef}
+            onChange={handleLogoChange}
+            className="hidden"
+            accept="image/*"
+          />
+          <div className="flex items-center justify-between">
+            <button
+              type="button"
+              onClick={() => fileInputRef.current?.click()}
+              className="px-4 py-2 border border-gray-300 rounded bg-white hover:bg-gray-50 text-sm"
+            >
+              Seleccionar archivo: Sin archivo seleccionado
+            </button>
+            {data.logo && (
+              <button
+                type="button"
+                onClick={handleLogoRemove}
+                className="text-gray-500 hover:text-red-500"
+              >
+                ✕
+              </button>
+            )}
+          </div>
+        </div>
+      </div>
+      
+      <div>
+        <Label htmlFor="logoPosition" className="block font-medium mb-2">Position</Label>
+        {/* Replace the custom Select component with a standard HTML select */}
+        <select
+          id="logoPosition"
+          value={data.logoPosition}
+          onChange={handleLogoPositionChange}
+          className="w-full p-2 border border-gray-300 rounded"
+        >
+          <option value="top">Top</option>
+          <option value="none">None</option>
+        </select>
+        <p className="text-xs text-gray-500 mt-1">Choose where to display your logo</p>
+      </div>
+    </div>
+  );
+};
+
+export default BrandingTab;

--- a/paystell-frontend/src/components/dashboard/links/builder/BrandingTab/types.ts
+++ b/paystell-frontend/src/components/dashboard/links/builder/BrandingTab/types.ts
@@ -1,0 +1,10 @@
+export type ColorPalette = 'modern-blue' | 'forest-green' | 'royal-purple' | 'sunset-orange' | 'ocean-blue' | 'dark-mode';
+
+export interface BrandingFormData {
+  colorPalette: ColorPalette;
+  primaryColor: string;
+  secondaryColor: string;
+  backgroundColor: string;
+  logo: File | null;
+  logoPosition: 'top' | 'none';
+}

--- a/paystell-frontend/src/components/dashboard/links/builder/PaymentLinkBuilder.tsx
+++ b/paystell-frontend/src/components/dashboard/links/builder/PaymentLinkBuilder.tsx
@@ -1,0 +1,92 @@
+import React, { useState } from 'react';
+import ProductTab from './ProductTab';
+import BrandingTab from './BrandingTab';
+import Preview from './Preview';
+// Fix the import path to ensure consistent casing
+import { ProductFormData } from './ProductTab/types';
+import { BrandingFormData } from './BrandingTab/types';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+
+const PaymentLinkBuilder: React.FC = () => {
+  const [activeTab, setActiveTab] = useState<'product' | 'branding'>('product');
+  
+  const initialProductData: ProductFormData = {
+    title: '',
+    description: '',
+    price: '',
+    currency: 'USDC',
+    image: null,
+    sku: '',
+    skut: ''
+  };
+
+  const initialBrandingData: BrandingFormData = {
+    colorPalette: 'modern-blue',
+    primaryColor: '#001A2C',
+    secondaryColor: '#FFFFFF',
+    backgroundColor: '#F1F5F9',
+    logo: null,
+    logoPosition: 'top'
+  };
+
+  const [productData, setProductData] = useState<ProductFormData>(initialProductData);
+  const [brandingData, setBrandingData] = useState<BrandingFormData>(initialBrandingData);
+
+  const handleProductChange = (newData: Partial<ProductFormData>) => {
+    setProductData(prev => ({ ...prev, ...newData }));
+  };
+
+  const handleBrandingChange = (newData: Partial<BrandingFormData>) => {
+    setBrandingData(prev => ({ ...prev, ...newData }));
+  };
+
+  const resetToDefault = () => {
+    setProductData(initialProductData);
+    setBrandingData(initialBrandingData);
+  };
+
+  return (
+    <div className="flex flex-col lg:flex-row w-full gap-6 p-4">
+      <div className="flex flex-col w-full lg:w-1/2">
+        <div className="flex justify-between items-center mb-4">
+          <h1 className="text-xl font-bold">Payment Link Builder</h1>
+          <button 
+            onClick={resetToDefault}
+            className="px-3 py-1 text-sm border border-gray-300 rounded hover:bg-gray-100"
+          >
+            Reset to Default
+          </button>
+        </div>
+        
+        <p className="text-sm text-gray-500 mb-4">Customize your product and payment link appearance</p>
+        
+        <div className="flex border-b mb-4">
+          <button
+            className={`py-2 px-4 ${activeTab === 'product' ? 'border-b-2 border-blue-500 font-medium' : 'text-gray-500'}`}
+            onClick={() => setActiveTab('product')}
+          >
+            Product
+          </button>
+          <button
+            className={`py-2 px-4 ${activeTab === 'branding' ? 'border-b-2 border-blue-500 font-medium' : 'text-gray-500'}`}
+            onClick={() => setActiveTab('branding')}
+          >
+            Branding
+          </button>
+        </div>
+        
+        {activeTab === 'product' ? (
+          <ProductTab data={productData} onChange={handleProductChange} />
+        ) : (
+          <BrandingTab data={brandingData} onChange={handleBrandingChange} />
+        )}
+      </div>
+      
+      <div className="w-full lg:w-1/2">
+        <Preview productData={productData} brandingData={brandingData} />
+      </div>
+    </div>
+  );
+};
+
+export default PaymentLinkBuilder;

--- a/paystell-frontend/src/components/dashboard/links/builder/Preview/index.tsx
+++ b/paystell-frontend/src/components/dashboard/links/builder/Preview/index.tsx
@@ -1,0 +1,101 @@
+import React from 'react';
+import { PreviewProps } from './types';
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+const Preview: React.FC<PreviewProps> = ({ productData, brandingData }) => {
+  const displayTitle = productData.title || 'Sample Product';
+  const displayDescription = productData.description || 'This is a sample product description';
+  const displayPrice = productData.price ? parseFloat(productData.price).toFixed(2) : '99.00';
+  const displayCurrency = productData.currency || 'USDC';
+  
+  // Create object URL for product image if it exists
+  const productImageUrl = productData.image ? URL.createObjectURL(productData.image) : null;
+  
+  // Create object URL for logo if it exists
+  const logoUrl = brandingData.logo ? URL.createObjectURL(brandingData.logo) : null;
+  
+  return (
+    <Card 
+      className="overflow-hidden max-w-md mx-auto"
+      style={{ backgroundColor: brandingData.backgroundColor }}
+    >
+      {/* Logo at top if position is 'top' */}
+      {brandingData.logoPosition === 'top' && logoUrl && (
+        <div className="p-4 flex justify-center">
+          <img src={logoUrl} alt="Brand Logo" className="h-10 object-contain" />
+        </div>
+      )}
+      
+      {/* Product Details */}
+      <div className="p-6">
+        <h2 
+          className="text-xl font-bold mb-2" 
+          style={{ color: brandingData.primaryColor }}
+        >
+          {displayTitle}
+        </h2>
+        
+        {/* Product Image if available */}
+        {productImageUrl && (
+          <div className="mb-4">
+            <img 
+              src={productImageUrl} 
+              alt={displayTitle} 
+              className="w-full h-48 object-cover rounded"
+            />
+          </div>
+        )}
+        
+        <p 
+          className="text-sm mb-4" 
+          style={{ color: brandingData.primaryColor }}
+        >
+          {displayDescription}
+        </p>
+        
+        <div className="mb-4">
+          <label 
+            className="block text-sm font-medium mb-1"
+            style={{ color: brandingData.primaryColor }}
+          >
+            Price
+          </label>
+          <div 
+            className="text-xl font-bold"
+            style={{ color: brandingData.primaryColor }}
+          >
+            {displayPrice} {displayCurrency}
+          </div>
+        </div>
+        
+        <Button
+          className="w-full text-white"
+          style={{ backgroundColor: brandingData.primaryColor }}
+        >
+          Pay Now
+        </Button>
+        
+        <div className="flex justify-center items-center mt-4 text-xs text-gray-500">
+          <svg 
+            xmlns="http://www.w3.org/2000/svg" 
+            className="h-4 w-4 mr-1" 
+            fill="none" 
+            viewBox="0 0 24 24" 
+            stroke="currentColor"
+          >
+            <path 
+              strokeLinecap="round" 
+              strokeLinejoin="round" 
+              strokeWidth={2} 
+              d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" 
+            />
+          </svg>
+          <span>Secure payment powered by PayStell</span>
+        </div>
+      </div>
+    </Card>
+  );
+};
+
+export default Preview;

--- a/paystell-frontend/src/components/dashboard/links/builder/Preview/types.ts
+++ b/paystell-frontend/src/components/dashboard/links/builder/Preview/types.ts
@@ -1,0 +1,7 @@
+import { ProductFormData } from '../ProductTab/types';
+import { BrandingFormData } from '../BrandingTab/types';
+
+export interface PreviewProps {
+  productData: ProductFormData;
+  brandingData: BrandingFormData;
+}

--- a/paystell-frontend/src/components/dashboard/links/builder/ProductTab/index.tsx
+++ b/paystell-frontend/src/components/dashboard/links/builder/ProductTab/index.tsx
@@ -1,0 +1,217 @@
+import React, { useState, useRef } from 'react';
+import { ProductFormData } from './types';
+import * as Form from "@radix-ui/react-form";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+// Fix: Import the select components correctly
+import { 
+  Select, 
+  SelectContent, 
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectTrigger,
+  SelectValue
+} from "@radix-ui/react-select";
+import { Label } from "@/components/ui/label";
+
+interface ProductTabProps {
+  data: ProductFormData;
+  onChange: (data: Partial<ProductFormData>) => void;
+}
+
+const ProductTab: React.FC<ProductTabProps> = ({ data, onChange }) => {
+  const [errors, setErrors] = useState<Partial<Record<keyof ProductFormData, string>>>({});
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  
+  const validateField = (name: keyof ProductFormData, value: string) => {
+    const newErrors = { ...errors };
+    
+    switch (name) {
+      case 'title':
+        if (!value.trim()) {
+          newErrors.title = 'Product title is required';
+        } else {
+          delete newErrors.title;
+        }
+        break;
+      case 'price':
+        if (!value.trim()) {
+          newErrors.price = 'Price is required';
+        } else if (isNaN(parseFloat(value)) || parseFloat(value) <= 0) {
+          newErrors.price = 'Price must be a positive number';
+        } else {
+          delete newErrors.price;
+        }
+        break;
+      default:
+        break;
+    }
+    
+    setErrors(newErrors);
+    return Object.keys(newErrors).length === 0;
+  };
+  
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => {
+    const { name, value } = e.target;
+    validateField(name as keyof ProductFormData, value);
+    onChange({ [name]: value });
+  };
+  
+  const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files && e.target.files[0];
+    if (file) {
+      onChange({ image: file });
+    }
+  };
+
+  const handleImageRemove = () => {
+    if (fileInputRef.current) {
+      fileInputRef.current.value = '';
+    }
+    onChange({ image: null });
+  };
+
+  return (
+    <Form.Root className="space-y-4">
+      <Form.Field name="title">
+        <div className="mb-2">
+          <Form.Label className="text-sm font-medium">
+            Product Title
+          </Form.Label>
+          <Form.Message className="text-red-500 text-xs" match="valueMissing">
+            Product title is required
+          </Form.Message>
+        </div>
+        <Form.Control asChild>
+          <Input
+            name="title"
+            value={data.title}
+            onChange={handleChange}
+            className={errors.title ? 'border-red-500' : ''}
+            placeholder="Sample Product"
+            required
+          />
+        </Form.Control>
+        {errors.title && <p className="text-red-500 text-xs mt-1">{errors.title}</p>}
+      </Form.Field>
+      
+      <div>
+        <Label htmlFor="description" className="block text-sm font-medium mb-1">Product Description</Label>
+        <Textarea
+          id="description"
+          name="description"
+          value={data.description}
+          onChange={handleChange}
+          rows={3}
+          placeholder="This is a sample product description"
+        />
+      </div>
+      
+      <div className="flex gap-4">
+        <Form.Field name="price" className="w-1/2">
+          <div className="mb-2">
+            <Form.Label className="text-sm font-medium">
+              Price
+            </Form.Label>
+            <Form.Message className="text-red-500 text-xs" match="valueMissing">
+              Price is required
+            </Form.Message>
+          </div>
+          <Form.Control asChild>
+            <Input
+              name="price"
+              value={data.price}
+              onChange={handleChange}
+              className={errors.price ? 'border-red-500' : ''}
+              placeholder="99"
+              required
+            />
+          </Form.Control>
+          {errors.price && <p className="text-red-500 text-xs mt-1">{errors.price}</p>}
+        </Form.Field>
+        
+        <div className="w-1/2">
+          <Label htmlFor="currency" className="block text-sm font-medium mb-1">Currency</Label>
+          {/* Fix: Update Select component usage to fix TypeScript errors */}
+          <Select
+            value={data.currency}
+            onValueChange={(value) => onChange({ currency: value })}
+          >
+            <SelectTrigger id="currency">
+              <SelectValue placeholder="Select currency" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="USDC">USDC</SelectItem>
+              <SelectItem value="ETH">ETH</SelectItem>
+              <SelectItem value="BTC">BTC</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+      
+      <div>
+        <label className="block text-sm font-medium mb-1">Product Image</label>
+        <div className="border border-gray-300 rounded p-4">
+          <input
+            type="file"
+            id="image"
+            name="image"
+            ref={fileInputRef}
+            onChange={handleImageChange}
+            className="hidden"
+            accept="image/*"
+          />
+          <div className="flex items-center justify-between">
+            <button
+              type="button"
+              onClick={() => fileInputRef.current?.click()}
+              className="px-4 py-2 border border-gray-300 rounded bg-white hover:bg-gray-50 text-sm"
+            >
+              Select image archive: Sin archivo seleccionado
+            </button>
+            {data.image && (
+              <button
+                type="button"
+                onClick={handleImageRemove}
+                className="text-gray-500 hover:text-red-500"
+              >
+                ✕
+              </button>
+            )}
+          </div>
+          {data.image && (
+            <p className="text-sm text-gray-500 mt-2">
+              Upload a product image (optional)
+            </p>
+          )}
+        </div>
+      </div>
+      
+      <div>
+        <Label htmlFor="sku" className="block text-sm font-medium mb-1">SKU (Optional)</Label>
+        <Input
+          id="sku"
+          name="sku"
+          value={data.sku}
+          onChange={handleChange}
+          placeholder="Enter product SKU"
+        />
+      </div>
+      
+      <div>
+        <Label htmlFor="skut" className="block text-sm font-medium mb-1">SKUt (Optional)</Label>
+        <Input
+          id="skut"
+          name="skut"
+          value={data.skut}
+          onChange={handleChange}
+          placeholder="Product SKUt (optional)"
+        />
+        <p className="text-xs text-gray-500 mt-1">Product SKUt keeping (Optional)</p>
+      </div>
+    </Form.Root>
+  );
+};
+
+export default ProductTab;

--- a/paystell-frontend/src/components/dashboard/links/builder/ProductTab/types.ts
+++ b/paystell-frontend/src/components/dashboard/links/builder/ProductTab/types.ts
@@ -1,0 +1,9 @@
+export interface ProductFormData {
+    title: string;
+    description: string;
+    price: string;
+    currency: string;
+    image: File | null;
+    sku: string;
+    skut: string;
+  }


### PR DESCRIPTION
### 📘 Issue Description
Implement a new Payment Link Builder component with a tabbed interface for Product and Branding sections, featuring a live preview panel.

### 🔍 Steps
1. **Create new component files** (Example structure):
   ```
   src/components/dashboard/links/builder/
   ├── PaymentLinkBuilder.tsx       // Main container component
   ├── ProductTab/
   │   ├── index.tsx               // Product form section
   │   └── types.ts                // Product form types
   ├── BrandingTab/
   │   ├── index.tsx               // Branding customization section (to be implemented)
   │   └── types.ts                // Branding types
   └── Preview/
       ├── index.tsx               // Live preview component
       └── types.ts                // Preview types
   ```
2. **Implement tab navigation:**
   - Product tab (default active)
   - Branding tab
   - Reset to Default button in the header

3. **Implement Product tab fields:**
   - Product Title (required)
   - Product Description
   - Price (required)
   - Currency selector (USDC default)
   - Product Image upload
   - SKU (optional)
   - SKUt (optional)

4. **Implement Preview panel:**
   - Product title
   - Description
   - Price with currency
   - Pay Now button
   - Logo
   - Product image
   - Secure payment footer
   - Real-time updates as the form is filled

### ✅ Acceptance Criteria
- Tabs switch correctly between Product and Branding sections.
- Product form implements all fields with proper validation.
- Preview panel updates in real-time.
- Reset to Default button clears all fields.
- Mobile responsive design.
- Form validation with error messages.
- Image upload with preview.
- Proper TypeScript types for all components.

### 🌎 References
- [Provide links to relevant documentation, Figma designs, or existing components]

### 📜 Additional Notes
- Any potential edge cases or considerations for future enhancements.

